### PR TITLE
Feat/addition of security policy for the repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/03-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/03-bug-report.yml
@@ -8,7 +8,8 @@ body:
       value: |
         > **Note:**
         > - For **bugs/issues/unexpected Behavior:** Use this template.
-        > - For **critical security issues:** Contact privately.
+        > - For **critical security Vulnerability:** Do not repot them here publicly.
+        > - Instead, submit the `Vulnerability Disclosure Form` as outlined in our [Security Policy](https://github.com/Himanshu-Parangat/cnss/security/policy).
 
   - type: markdown
     attributes:

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,120 @@
+# Security Policy
+
+> This living document details the current security policy for the project.
+
+## Table of Contents
+
+- [1. Security Policy Overview](#1-security-policy-overview)
+- [2. How to Report a Security Vulnerability](#2-how-to-report-a-security-vulnerability)
+- [3. How We Handle Security Reports](#3-how-we-handle-security-reports)
+- [4. What is a Security Issue?](#4-what-is-a-security-issue)
+  - [4.1 Examples of Security Issues](#41-examples-of-security-issues)
+  - [4.2 Not Security Issues (Report as Regular Issues)](#42-not-security-issues-report-as-regular-issues)
+- [5. Security Best Practices for Everyone](#5-security-best-practices-for-everyone)
+  - [5.1 For Developers](#51-for-developers)
+- [6. Legal and Ethical Points](#6-legal-and-ethical-points)
+- [7. Scope of this Policy](#7-scope-of-this-policy)
+- [8. Policy Updates](#8-policy-updates)
+
+## 1. Security Policy Overview
+
+This document details the security policy for this project. It is designed for reporting **critical security vulnerabilities** that could negatively inpact users, contributors, collaborators, the project itself, the repository owner/maintainer, and everyone else involved significantly.
+
+### Key Points:
+
+- **Purpose:** To provide a clear process for reporting critical security issues.
+- **Focus:** **Critical Security Vulnerabilities** only.
+- **Not for:** General bugs or feature requests. Use the standard issue tracker for those.
+
+## 2. How to Report a Security Vulnerability
+
+If you discover a critical security vulnerability, please follow these steps:
+
+1. **Keep it Private:** **Do not publicly disclose** the vulnerability.
+2. **Direct Contact:** Reach out to us directly via `Vulnerability Disclosure Form`.
+3. **Report Details:** Include the following information in your report:
+   - **Clear Description:** A concise explanation of the vulnerability.
+   - **Reproduction Steps:** Detailed steps to recreate the vulnerability.
+   - **Potential Impact:** Describe the possible harm the vulnerability could cause.
+   - **Supporting Materials:** Attach any relevant files like screenshots, code snippets, or proof-of-concept.
+   - **Contact Information:** Your contact details (optional, if you wish to be contacted).
+
+## 3. How We Handle Security Reports
+
+Our process for handling security reports:
+
+1. **Acknowledgement:** We will confirm receipt of your report within **24-48 hours**.
+2. **Investigation:** We will thoroughly examine the vulnerability and assess its potential impact.
+3. **Solution Development:** We will prioritize developing and releasing a patch or fix as quickly as possible.
+4. **Communication:** We will keep you informed about our progress in resolving the issue.
+5. **Recognition (Optional):** With your permission, we may publicly acknowledge your responsible disclosure.
+
+## 4. What is a Security Issue?
+>  [!note]
+> - A **critical security issue** is something that includes, but is not limited to, the following. 
+> - If an issue is not mentioned but you believe it poses a security risk, **please do report** it.
+
+- **Compromises Confidentiality:** Could lead to unauthorized access or exposure of sensitive data like:
+  - API keys
+  - User credentials
+  - Personal data
+- **Enables Malicious Actions:** Could allow an attacker to:
+  - Execute arbitrary code on the system.
+  - Launch a denial-of-service (DoS) attack to disrupt service.
+  - Bypass security restrictions.
+  - Create a new attack vector.
+  - Turn the project into a harmful or dangerous environment.
+- **Causes Data Leaks:** Includes unintentional exposure of important data.
+- **Risks User Systems:** Anything that could put a user's computer or data at risk.
+
+### 4.1 Examples of Security Issues
+
+- Exposed API keys or login credentials.
+- Cross-Site Scripting (XSS) vulnerabilities.
+- Remote Code Execution (RCE) vulnerabilities.
+- Insecure Direct Object Reference vulnerabilities.
+
+### 4.2 Not Security Issues (Report as Regular Issues)
+
+- Minor visual (UI) bugs.
+- Performance slowdowns that don't create a security risk.
+- Suggestions for new features or improvements.
+
+## 5. Security Best Practices for Everyone
+
+To help maintain security:
+
+- **Command Awareness:** Understand the commands you are executing.
+- **Keep Software Updated:** Regularly update your systems and software.
+- **Link & Attachment Caution:** Be wary of clicking on suspicious links or opening unexpected attachments.
+- **Immediate Reporting:** If you suspect any security incident, report it right away.
+- **Development Environment:** Work in a dedicated and controlled environment specifically for development.
+
+### 5.1 For Developers
+
+- **Least Privilege:** Grant only the necessary permissions.
+- **Input Sanitization:** Clean and validate all user inputs to prevent attacks.
+- **Follow Security Practices:** Implement standard security best practices during development.
+
+## 6. Legal and Ethical Points
+
+Important considerations for security reporting:
+
+- **Responsible Disclosure:** It is crucial to report vulnerabilities privately and allow us time to fix them before public disclosure.
+- **No Unauthorized Exploitation:** Attempting to exploit security issues without permission is illegal and unethical.
+- **Collaboration is Valued:** We appreciate your help in keeping our project secure for everyone.
+- **Production Environment Prohibition:** Exploiting vulnerabilities in a live production environment without explicit consent is strictly forbidden.
+- **Dummy Data in Reports:** When submitting reports, do not include real sensitive data. Replace any sensitive information with fake or dummy data for examples.
+
+## 7. Scope of this Policy
+
+This policy covers all parts of this project:
+
+- **Source Code:** All code within the repository.
+- **Websites:** Project websites and web applications.
+- **APIs:** Application Programming Interfaces.
+- **Documentation:** All project documentation.
+
+## 8. Policy Updates
+
+**Policy Changes:** This security policy may be updated periodically as per need, Please check back here for the most current version of the policy.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,6 +2,10 @@
 
 > This living document details the current security policy for the project.
 
+
+> [!IMPORTANT]
+> Thank you for reaching out. Please adhere to the **security policy below** and report any critical issues using the quick link to the [Vulnerability Disclosure Form](https://forms.gle/5mkvFaHuSvRdYqCU8).
+
 ## Table of Contents
 
 - [1. Security Policy Overview](#1-security-policy-overview)


### PR DESCRIPTION
- In respond to https://github.com/Himanshu-Parangat/cnss/issues/18
- drafted a security policy.
- addition of `.github/SECURITY.md`
- making a Vulnerability Disclosure Form. 
- adding VDF to `.github/SECURITY.md` highlighted as quick link.
- adding security policy link to the bug report template `.github/ISSUE_TEMPLATE/03-bug-report.yml`

Note: no link to `.github/ISSUE_TEMPLATE/config.yml` because github auto generates it.